### PR TITLE
Encode redirect URL value

### DIFF
--- a/src/main/java/com/example/FakeAuthServlet.java
+++ b/src/main/java/com/example/FakeAuthServlet.java
@@ -18,6 +18,7 @@ package com.example;
 
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -36,7 +37,7 @@ public class FakeAuthServlet extends HttpServlet {
             URLDecoder.decode(req.getParameter("redirect_uri"), "UTF8"),
             "xxxxxx",
             req.getParameter("state"));
-    String loginUrl = res.encodeRedirectURL("/login?responseurl=" + redirectURL);
+    String loginUrl = res.encodeRedirectURL("/login?responseurl=" + URLEncoder.encode(redirectURL, "UTF8"));
     res.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
     res.setHeader("Location", loginUrl);
     res.getWriter().flush();


### PR DESCRIPTION
I am not completely sure why does `encodeRedirectURL` not handle this. Documentation for this method states that it tries to determine whether encoding is needed or not. And for some reason it does not encode provided `redirectURL`.

When `redirectURL` is not encoded, only the first argument (`code`) is then taken from the URL in the `/link` endpoint.

When `redirectURL` is encoded, both `code` and `state` is parsed from the URL correctly and Google endpoint does not complain about missing `state` argument anymore.