### PR TITLE
Fix resource path

### DIFF
--- a/src/main/java/com/example/SmartHomeCreateServlet.java
+++ b/src/main/java/com/example/SmartHomeCreateServlet.java
@@ -49,7 +49,7 @@ public class SmartHomeCreateServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("smart-home-key.json"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeDeleteServlet.java
+++ b/src/main/java/com/example/SmartHomeDeleteServlet.java
@@ -47,7 +47,7 @@ public class SmartHomeDeleteServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("smart-home-key.json"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeServlet.java
+++ b/src/main/java/com/example/SmartHomeServlet.java
@@ -48,7 +48,7 @@ public class SmartHomeServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("smart-home-key.json"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOG.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeUpdateServlet.java
+++ b/src/main/java/com/example/SmartHomeUpdateServlet.java
@@ -54,7 +54,7 @@ public class SmartHomeUpdateServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("smart-home-key.json"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");


### PR DESCRIPTION
I was getting the following error in the logs before this fix:

```
"errorCode":"You must pass credentials in the app constructor","status":"ERROR"
```

Also, this fix was originally mentioned in https://github.com/actions-on-google/smart-home-java/issues/10#issuecomment-639776777