### PR TITLE
Separate response and homegraph states

### DIFF
--- a/src/main/java/com/example/MySmartHomeApp.java
+++ b/src/main/java/com/example/MySmartHomeApp.java
@@ -142,9 +142,10 @@ public class MySmartHomeApp extends SmartHomeApp {
     for (QueryRequest.Inputs.Payload.Device device : devices) {
       try {
         Map<String, Object> deviceState = database.getState(userId, device.id);
-        deviceState.put("status", "SUCCESS");
-        deviceStates.put(device.id, deviceState);
         ReportState.makeRequest(this, userId, device.id, deviceState);
+        Map<String, Object> successDevice = new HashMap<>(deviceState);
+        successDevice.put("status", "SUCCESS");
+        deviceStates.put(device.id, successDevice);
       } catch (Exception e) {
         LOGGER.error("QUERY FAILED: {}", e);
         Map<String, Object> failedDevice = new HashMap<>();


### PR DESCRIPTION
This fixes the following error:

```
ERROR:: QUERY FAILED: {}
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Request contains an invalid argument.
```

Homegraph ReportState does not expect to get `status=SUCCESS` but only
device state as mentioned here: https://github.com/actions-on-google/actions-on-google-java/blob/7f3b1e2fd51e3b044380ea3c72722058ad99240f/src/main/proto/google/home/graph/v1/homegraph.proto#L132